### PR TITLE
[Fixes]:Instagram sharing option not working #83

### DIFF
--- a/newsaggregator/templates/components/news.html
+++ b/newsaggregator/templates/components/news.html
@@ -34,8 +34,9 @@
                         </div>
                         <div class="">
                             <div class="btns" role="group">
-                                <a href="https://www.instagram.com/share?url={{ record.url }}" target="_blank"
-                                    class="social-icon fa fa-instagram" aria-label="Share on Instagram"></a>
+                                <!-- <a href="https://www.instagram.com/share?url={{ record.url }}" target="_blank"
+                                    class="social-icon fa fa-instagram" aria-label="Share on Instagram"></a> -->
+                                <a class="btn btn-secondary social-icon fa fa-instagram" aria-label="Share on Instagram" onclick="shareOnInstagram('{{ record.url }}')"></a>
                                 <a href="https://api.whatsapp.com/send?text=Check%20out%20this%20link:%20{{ record.url }}"
                                     target="_blank" class="social-icon fa fa-whatsapp"
                                     aria-label="Share on WhatsApp"></a>
@@ -340,6 +341,11 @@
             button.classList.remove('btn-secondary');
             button.classList.add('btn-danger');
         }
+    }
+
+    function shareOnInstagram(url) {
+            copyToClipboard(url);
+            window.location.href = "instagram://";
     }
 });
 </script>


### PR DESCRIPTION
## Related Issue
#83 

## Description
Since there is no direct option available to share on instagram, so i have added the functionality to open the instagram page and copied the message on clipboard so that the user can directly send the message.

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
